### PR TITLE
fix: use timezone aware tokens

### DIFF
--- a/apps/backend/app/core/security.py
+++ b/apps/backend/app/core/security.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import jwt
 from passlib.context import CryptContext
 from .config import settings
@@ -14,7 +14,9 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.access_token_expire_minutes))
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=settings.access_token_expire_minutes)
+    )
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=ALGORITHM)
     return encoded_jwt


### PR DESCRIPTION
## Summary
- handle JWT expirations using timezone-aware datetime to avoid deprecation warnings

## Testing
- `pnpm -w lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5f8adf18832fa9c326b26e806fe9